### PR TITLE
Use Cairo backend

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         swift-version: ${{ matrix.swift }}
     - name: Install dependencies (Linux)
       if: runner.os == 'Linux'
-      run: sudo apt-get install -y libtinyxml2-dev libcairomm-1.16-1 libpangomm-2.48-1 libfontconfig1-dev
+      run: sudo apt-get install -y libtinyxml2-dev libcairomm-1.16-dev libpangomm-2.48-dev libfontconfig1-dev
     - name: Install dependencies (macOS)
       if: runner.os == 'macOS'
       run: brew install tinyxml2 cairomm pangomm fontconfig

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'macos-latest']
+        # TODO: On macOS a development/trunk toolchain is needed until
+        # https://github.com/apple/swift-package-manager/pull/6772 is included
+        # in a release.
+        os: ['ubuntu-latest']
         swift: ['5.9']
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,9 +20,9 @@ jobs:
         swift-version: ${{ matrix.swift }}
     - name: Install dependencies (Linux)
       if: runner.os == 'Linux'
-      run: sudo apt-get install -y libtinyxml2-dev
+      run: sudo apt-get install -y libtinyxml2-dev libcairomm-1.16-1 libpangomm-2.48-1
     - name: Install dependencies (macOS)
       if: runner.os == 'macOS'
-      run: brew install tinyxml2
+      run: brew install tinyxml2 cairomm pangomm
     - name: Build
       run: swift build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,9 @@ jobs:
         swift-version: ${{ matrix.swift }}
     - name: Install dependencies (Linux)
       if: runner.os == 'Linux'
-      run: sudo apt-get install -y libtinyxml2-dev libcairomm-1.16-1 libpangomm-2.48-1
+      run: sudo apt-get install -y libtinyxml2-dev libcairomm-1.16-1 libpangomm-2.48-1 libfontconfig1-dev
     - name: Install dependencies (macOS)
       if: runner.os == 'macOS'
-      run: brew install tinyxml2 cairomm pangomm
+      run: brew install tinyxml2 cairomm pangomm fontconfig
     - name: Build
       run: swift build

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "Sources/CppMicroTeX/MicroTeX"]
 	path = MicroTeX
-	url = https://github.com/NanoMichael/MicroTeX.git
+	url = ../microtex.git
+  branch = swift

--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,7 @@ let package = Package(
         .target(
             name: "CxxMicroTeX",
             dependencies: [
+                .target(name: "CFontConfig"),
                 .target(name: "CTinyXML2"),
                 .target(name: "CxxCairomm"),
                 .target(name: "CxxPangomm"),
@@ -52,6 +53,14 @@ let package = Package(
             cxxSettings: [
                 .define("BUILD_GTK"),
                 .unsafeFlags(["-std=c++17", "-UDEBUG"]),
+            ]
+        ),
+        .systemLibrary(
+            name: "CFontConfig",
+            pkgConfig: "fontconfig",
+            providers: [
+                .apt(["libfontconfig1-dev"]),
+                .brew(["fontconfig"]),
             ]
         ),
         .systemLibrary(

--- a/Package.swift
+++ b/Package.swift
@@ -18,9 +18,14 @@ let package = Package(
         // Targets can depend on other targets in this package and products from dependencies.
         .target(
             name: "CxxMicroTeX",
-            dependencies: [.target(name: "CTinyXML2")],
+            dependencies: [
+                .target(name: "CTinyXML2"),
+                .target(name: "CxxCairomm"),
+                .target(name: "CxxPangomm"),
+            ],
             path: "./MicroTeX",
             exclude: [
+                "src/samples",
                 // (cd MicroTeX && find src -type f ! \( -name '*.cpp' -o -name '*.h' \)) | sort
                 // TODO: Automate this (or figure out if there's some way to glob from SPM?)
                 "src/QtLatex.pri",
@@ -40,12 +45,14 @@ let package = Package(
                 "src/res/parser/meson.build",
                 "src/res/reg/meson.build",
                 "src/res/sym/meson.build",
-                "src/samples/meson.build",
                 "src/utils/meson.build",
             ],
             sources: ["src"],
             publicHeadersPath: "src",
-            cxxSettings: [.unsafeFlags(["-std=c++17", "-UDEBUG"])]
+            cxxSettings: [
+                .define("BUILD_GTK"),
+                .unsafeFlags(["-std=c++17", "-UDEBUG"]),
+            ]
         ),
         .systemLibrary(
             name: "CTinyXML2",
@@ -53,6 +60,22 @@ let package = Package(
             providers: [
                 .apt(["libtinyxml2-dev"]),
                 .brew(["tinyxml2"]),
+            ]
+        ),
+        .systemLibrary(
+            name: "CxxCairomm",
+            pkgConfig: "cairomm-1.16",
+            providers: [
+                // TODO: Figure out the apt package
+                .brew(["cairomm"]),
+            ]
+        ),
+        .systemLibrary(
+            name: "CxxPangomm",
+            pkgConfig: "pangomm-2.48",
+            providers: [
+                // TODO: Figure out the apt package
+                .brew(["pangomm"]),
             ]
         ),
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -66,7 +66,7 @@ let package = Package(
             name: "CxxCairomm",
             pkgConfig: "cairomm-1.16",
             providers: [
-                // TODO: Figure out the apt package
+                .apt(["libcairomm-1.16-1"]),
                 .brew(["cairomm"]),
             ]
         ),
@@ -74,7 +74,7 @@ let package = Package(
             name: "CxxPangomm",
             pkgConfig: "pangomm-2.48",
             providers: [
-                // TODO: Figure out the apt package
+                .apt(["libpangomm-2.48-1"]),
                 .brew(["pangomm"]),
             ]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -75,7 +75,7 @@ let package = Package(
             name: "CxxCairomm",
             pkgConfig: "cairomm-1.16",
             providers: [
-                .apt(["libcairomm-1.16-1"]),
+                .apt(["libcairomm-1.16-dev"]),
                 .brew(["cairomm"]),
             ]
         ),
@@ -83,7 +83,7 @@ let package = Package(
             name: "CxxPangomm",
             pkgConfig: "pangomm-2.48",
             providers: [
-                .apt(["libpangomm-2.48-1"]),
+                .apt(["libpangomm-2.48-dev"]),
                 .brew(["pangomm"]),
             ]
         ),

--- a/README.md
+++ b/README.md
@@ -3,3 +3,6 @@
 [![Build](https://github.com/fwcd/swift-microtex/actions/workflows/build.yml/badge.svg)](https://github.com/fwcd/swift-microtex/actions/workflows/build.yml)
 
 A Swift wrapper around the embeddable LaTeX renderer [MicroTeX](https://github.com/NanoMichael/MicroTeX).
+
+> [!NOTE]
+> On macOS a Swift development toolchain is currently needed until https://github.com/apple/swift-package-manager/pull/6772 makes its way into a stable release

--- a/Sources/CFontConfig/module.modulemap
+++ b/Sources/CFontConfig/module.modulemap
@@ -1,0 +1,5 @@
+module CFontConfig {
+    header "fontconfig/fontconfig.h"
+    link "fontconfig"
+    export *
+}

--- a/Sources/CxxCairomm/module.modulemap
+++ b/Sources/CxxCairomm/module.modulemap
@@ -1,0 +1,5 @@
+module CxxCairomm {
+    header "cairomm/cairomm.h"
+    link "cairomm"
+    export *
+}

--- a/Sources/CxxPangomm/module.modulemap
+++ b/Sources/CxxPangomm/module.modulemap
@@ -1,0 +1,5 @@
+module CxxPangomm {
+    header "pangomm/pangomm.h"
+    link "pangomm"
+    export *
+}


### PR DESCRIPTION
Currently, the package build fails with a linker error noting that `TextLayout::create` could not be found. This is because this function is defined differently for each platform and we haven't picked one.

Since Cairo is cross-platform and we already use it in other Swift project, it should be a good fit. Using the latest version of `cairomm`, however, requires migrating some API changes, therefore we'll fork/vendor MicroTeX for now.